### PR TITLE
Fix Crab and Shark Spawning

### DIFF
--- a/java/net/divinerpg/entities/vanilla/EntityShark.java
+++ b/java/net/divinerpg/entities/vanilla/EntityShark.java
@@ -13,17 +13,15 @@ import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.potion.Potion;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.MathHelper;
-import net.minecraft.world.EnumDifficulty;
 import net.minecraft.world.World;
 
 public class EntityShark extends EntityPeacefulUntilAttacked {
 	
     public EntityShark(World var1) {
         super(var1);
-        this.setSize(0.95F, 0.95F);
+        this.setSize(0.75F, 0.75F);
     }
 
     @Override
@@ -34,6 +32,7 @@ public class EntityShark extends EntityPeacefulUntilAttacked {
         this.getEntityAttribute(SharedMonsterAttributes.movementSpeed).setBaseValue(net.divinerpg.api.entity.EntityStats.sharkSpeed);
         this.getEntityAttribute(SharedMonsterAttributes.followRange).setBaseValue(net.divinerpg.api.entity.EntityStats.sharkFollowRange);
     }
+
     
     @Override
 	public int getMaxSpawnedInChunk() {
@@ -108,10 +107,10 @@ public class EntityShark extends EntityPeacefulUntilAttacked {
 
     @Override
     public boolean getCanSpawnHere() {
-        return this.isInWater() && this.worldObj.difficultySetting != EnumDifficulty.PEACEFUL;
+        return this.worldObj.handleMaterialAcceleration(this.boundingBox.expand(0.0D, -0.6000000238418579D, 0.0D), Material.water, this);
     }
     
-    @Override
+	@Override
     public void onDeath(DamageSource d) {
 		super.onDeath(d);
 		if(!this.worldObj.isRemote) {

--- a/java/net/divinerpg/utils/entities/MobSpawning.java
+++ b/java/net/divinerpg/utils/entities/MobSpawning.java
@@ -218,7 +218,7 @@ public class MobSpawning {
 						EntityRegistry.addSpawn(EntityShark.class, 1, 1, 1, EnumCreatureType.waterCreature, biome);
 					}
 					if (BiomeDictionary.isBiomeOfType(biome, Type.BEACH)) {
-						EntityRegistry.addSpawn(EntityCrab.class, 15, 4, 4, EnumCreatureType.creature, biome);
+						EntityRegistry.addSpawn(EntityCrab.class, 15, 4, 4, EnumCreatureType.monster, biome);
 						EntityRegistry.addSpawn(EntityKingCrab.class, 5, 4, 4, EnumCreatureType.monster, biome);
 					}
 					if (BiomeDictionary.isBiomeOfType(biome, Type.JUNGLE)) {


### PR DESCRIPTION
It looks like the change to canSpawnHere() also stopped Sharks from spawning.

With these settings Sharks were spawning. Some Sharks hovered a bit below the surface and some came to the surface. I liked that.

Changing Crabs to monsters instead of creatures fixed their spawning issue for me.
