### PR TITLE
Fixed UpdateChecker crash

### DIFF
--- a/java/net/divinerpg/utils/events/UpdateChecker.java
+++ b/java/net/divinerpg/utils/events/UpdateChecker.java
@@ -41,7 +41,7 @@ public class UpdateChecker {
 	}
 	
 	public static String getCurrentVersion() throws MalformedURLException, IOException {
-		BufferedReader versionFile = new BufferedReader(new InputStreamReader(new URL("https://raw.github.com/DivineRPG/DivineRPG/master/Version.txt").openStream()));
+		BufferedReader versionFile = new BufferedReader(new InputStreamReader(new URL("https://raw.githubusercontent.com/DivineRPG/DivineRPG/master/Version.txt").openStream()));
 		String curVersion = versionFile.readLine();
 		versionFile.close();
 		return curVersion;


### PR DESCRIPTION
GitHub changed the way they did raw links, so the file link had to be changed