### PR TITLE
Tags are now more universal with forge tags and more flexible

### DIFF
--- a/src/main/resources/data/forge/tags/blocks/chests.json
+++ b/src/main/resources/data/forge/tags/blocks/chests.json
@@ -1,9 +1,9 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:eden_chest",
-    "divinerpg:bone_chest",
-    "divinerpg:present_box",
-    "divinerpg:frosted_chest"
+    "#forge:chests/eden",
+    "#forge:chests/bone",
+    "#forge:chests/present",
+    "#forge:chests/frosted"
   ]
 }

--- a/src/main/resources/data/forge/tags/blocks/chests/bone.json
+++ b/src/main/resources/data/forge/tags/blocks/chests/bone.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:bone_chest"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/chests/eden.json
+++ b/src/main/resources/data/forge/tags/blocks/chests/eden.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eden_chest"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/chests/frosted.json
+++ b/src/main/resources/data/forge/tags/blocks/chests/frosted.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:frosted_chest"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/chests/present.json
+++ b/src/main/resources/data/forge/tags/blocks/chests/present.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:present_box"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/dirt.json
+++ b/src/main/resources/data/forge/tags/blocks/dirt.json
@@ -1,21 +1,13 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:frozen_dirt",
-    "divinerpg:frozen_grass",
-    "divinerpg:eden_dirt",
-    "divinerpg:eden_grass",
-    "divinerpg:wildwood_dirt",
-    "divinerpg:wildwood_grass",
-    "divinerpg:apalachia_dirt",
-    "divinerpg:apalachia_grass",
-    "divinerpg:skythern_dirt",
-    "divinerpg:skythern_grass",
-    "divinerpg:mortum_dirt",
-    "divinerpg:mortum_grass",
-    "divinerpg:arcanite_dirt",
-    "divinerpg:arcanite_grass",
-    "divinerpg:dream_dirt",
-    "divinerpg:dream_grass"
+    "#forge:dirts/frozen",
+    "#forge:dirts/eden",
+    "#forge:dirts/wildwood",
+    "#forge:dirts/apalachia",
+    "#forge:dirts/skythern",
+    "#forge:dirts/mortum",
+    "#forge:dirts/arcanite",
+    "#forge:dirts/dream"
   ]
 }

--- a/src/main/resources/data/forge/tags/blocks/dirts/apalachia.json
+++ b/src/main/resources/data/forge/tags/blocks/dirts/apalachia.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:apalachia_dirt",
+    "divinerpg:apalachia_grass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/dirts/arcanite.json
+++ b/src/main/resources/data/forge/tags/blocks/dirts/arcanite.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:arcanite_dirt",
+    "divinerpg:arcanite_grass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/dirts/dream.json
+++ b/src/main/resources/data/forge/tags/blocks/dirts/dream.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:dream_dirt",
+    "divinerpg:dream_grass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/dirts/eden.json
+++ b/src/main/resources/data/forge/tags/blocks/dirts/eden.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eden_dirt",
+    "divinerpg:eden_grass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/dirts/frozen.json
+++ b/src/main/resources/data/forge/tags/blocks/dirts/frozen.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:frozen_dirt",
+    "divinerpg:frozen_grass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/dirts/mortum.json
+++ b/src/main/resources/data/forge/tags/blocks/dirts/mortum.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:mortum_dirt",
+    "divinerpg:mortum_grass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/dirts/skythern.json
+++ b/src/main/resources/data/forge/tags/blocks/dirts/skythern.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:skythern_dirt",
+    "divinerpg:skythern_grass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/dirts/wildwood.json
+++ b/src/main/resources/data/forge/tags/blocks/dirts/wildwood.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:wildwood_dirt",
+    "divinerpg:wildwood_grass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fence_gates.json
+++ b/src/main/resources/data/forge/tags/blocks/fence_gates.json
@@ -1,13 +1,13 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:eden_fence_gate",
-    "divinerpg:wildwood_fence_gate",
-    "divinerpg:apalachia_fence_gate",
-    "divinerpg:skythern_fence_gate",
-    "divinerpg:mortum_fence_gate",
-    "divinerpg:divine_fence_gate",
-    "divinerpg:frozen_fence_gate",
-    "divinerpg:eucalyptus_fence_gate"
+    "#forge:fence_gates/eden",
+    "#forge:fence_gates/wildwood",
+    "#forge:fence_gates/apalachia",
+    "#forge:fence_gates/skythern",
+    "#forge:fence_gates/mortum",
+    "#forge:fence_gates/divine",
+    "#forge:fence_gates/frozen",
+    "#forge:fence_gates/eucalyptus"
   ]
 }

--- a/src/main/resources/data/forge/tags/blocks/fence_gates/apalachia.json
+++ b/src/main/resources/data/forge/tags/blocks/fence_gates/apalachia.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:apalachia_fence_gate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fence_gates/divine.json
+++ b/src/main/resources/data/forge/tags/blocks/fence_gates/divine.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:divine_fence_gate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fence_gates/eden.json
+++ b/src/main/resources/data/forge/tags/blocks/fence_gates/eden.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eden_fence_gate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fence_gates/eucalyptus.json
+++ b/src/main/resources/data/forge/tags/blocks/fence_gates/eucalyptus.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eucalyptus_fence_gate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fence_gates/frozen.json
+++ b/src/main/resources/data/forge/tags/blocks/fence_gates/frozen.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:frozen_fence_gate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fence_gates/mortum.json
+++ b/src/main/resources/data/forge/tags/blocks/fence_gates/mortum.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:mortum_fence_gate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fence_gates/skythern.json
+++ b/src/main/resources/data/forge/tags/blocks/fence_gates/skythern.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:skythern_fence_gate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fence_gates/wildwood.json
+++ b/src/main/resources/data/forge/tags/blocks/fence_gates/wildwood.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:wildwood_fence_gate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fences.json
+++ b/src/main/resources/data/forge/tags/blocks/fences.json
@@ -1,16 +1,16 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:blue_fence",
-    "divinerpg:green_fence",
-    "divinerpg:red_fence",
-    "divinerpg:eden_fence",
-    "divinerpg:wildwood_fence",
-    "divinerpg:apalachia_fence",
-    "divinerpg:skythern_fence",
-    "divinerpg:mortum_fence",
-    "divinerpg:divine_fence",
-    "divinerpg:frozen_fence",
-    "divinerpg:eucalyptus_fence"
+    "#forge:fences/blue",
+    "#forge:fences/green",
+    "#forge:fences/red",
+    "#forge:fences/eden",
+    "#forge:fences/wildwood",
+    "#forge:fences/apalachia",
+    "#forge:fences/skythern",
+    "#forge:fences/mortum",
+    "#forge:fences/divine",
+    "#forge:fences/frozen",
+    "#forge:fences/eucalyptus"
   ]
 }

--- a/src/main/resources/data/forge/tags/blocks/fences/apalachia.json
+++ b/src/main/resources/data/forge/tags/blocks/fences/apalachia.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:apalachia_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fences/blue.json
+++ b/src/main/resources/data/forge/tags/blocks/fences/blue.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:blue_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fences/divine.json
+++ b/src/main/resources/data/forge/tags/blocks/fences/divine.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:divine_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fences/eden.json
+++ b/src/main/resources/data/forge/tags/blocks/fences/eden.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eden_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fences/eucalyptus.json
+++ b/src/main/resources/data/forge/tags/blocks/fences/eucalyptus.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eucalyptus_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fences/frozen.json
+++ b/src/main/resources/data/forge/tags/blocks/fences/frozen.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:frozen_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fences/green.json
+++ b/src/main/resources/data/forge/tags/blocks/fences/green.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:green_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fences/mortum.json
+++ b/src/main/resources/data/forge/tags/blocks/fences/mortum.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:mortum_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fences/red.json
+++ b/src/main/resources/data/forge/tags/blocks/fences/red.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:red_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fences/skythern.json
+++ b/src/main/resources/data/forge/tags/blocks/fences/skythern.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:skythern_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/fences/wildwood.json
+++ b/src/main/resources/data/forge/tags/blocks/fences/wildwood.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:wildwood_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/glass.json
+++ b/src/main/resources/data/forge/tags/blocks/glass.json
@@ -1,15 +1,8 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:frosted_glass",
-    "divinerpg:stained_glass8",
-    "divinerpg:stained_glass",
-    "divinerpg:stained_glass2",
-    "divinerpg:stained_glass3",
-    "divinerpg:stained_glass4",
-    "divinerpg:stained_glass5",
-    "divinerpg:stained_glass6",
-    "divinerpg:stained_glass7",
-    "divinerpg:smooth_glass"
+    "#forge:glass/frosted",
+    "#forge:glass/stained",
+    "#forge:glass/smooth"
   ]
 }

--- a/src/main/resources/data/forge/tags/blocks/glass/frosted.json
+++ b/src/main/resources/data/forge/tags/blocks/glass/frosted.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:frosted_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/glass/smooth.json
+++ b/src/main/resources/data/forge/tags/blocks/glass/smooth.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:smooth_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/glass/stained.json
+++ b/src/main/resources/data/forge/tags/blocks/glass/stained.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:smooth_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/ores.json
+++ b/src/main/resources/data/forge/tags/blocks/ores.json
@@ -1,15 +1,15 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:arlemite_ore",
-    "divinerpg:realmite_ore",
-    "divinerpg:rupee_ore",
-    "divinerpg:bloodgem_ore",
-    "divinerpg:torridite_ore",
-    "divinerpg:eden_ore",
-    "divinerpg:wildwood_ore",
-    "divinerpg:apalachia_ore",
-    "divinerpg:skythern_ore",
-    "divinerpg:mortum_ore"
+    "#forge:ores/arlemite",
+    "#forge:ores/realmite",
+    "#forge:ores/rupee",
+    "#forge:ores/bloodgem",
+    "#forge:ores/torridite",
+    "#forge:ores/eden",
+    "#forge:ores/wildwood",
+    "#forge:ores/apalachia",
+    "#forge:ores/skythern",
+    "#forge:ores/mortum"
   ]
 }

--- a/src/main/resources/data/forge/tags/blocks/ores/apalachia.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/apalachia.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:apalachia_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/ores/arlemite.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/arlemite.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:arlemite_ore",
+    "divinerpg:arlemite_ore_deepslate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/ores/bloodgem.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/bloodgem.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:bloodgem_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/ores/eden.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/eden.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eden_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/ores/mortum.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/mortum.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:mortum_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/ores/realmite.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/realmite.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:realmite_ore",
+    "divinerpg:realmite_ore_deepslate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/ores/rupee.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/rupee.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:rupee_ore",
+    "divinerpg:rupee_ore_deepslate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/ores/skythern.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/skythern.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:skythern_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/ores/torridite.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/torridite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:torridite_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/ores/wildwood.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/wildwood.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:wildwood_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/stained_glass.json
+++ b/src/main/resources/data/forge/tags/blocks/stained_glass.json
@@ -1,13 +1,13 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:stained_glass",
-    "divinerpg:stained_glass2",
-    "divinerpg:stained_glass3",
-    "divinerpg:stained_glass4",
-    "divinerpg:stained_glass5",
-    "divinerpg:stained_glass6",
-    "divinerpg:stained_glass7",
-    "divinerpg:stained_glass8"
+    "#forge:stained_glass/stained_glass",
+    "#forge:stained_glass/stained_glass2",
+    "#forge:stained_glass/stained_glass3",
+    "#forge:stained_glass/stained_glass4",
+    "#forge:stained_glass/stained_glass5",
+    "#forge:stained_glass/stained_glass6",
+    "#forge:stained_glass/stained_glass7",
+    "#forge:stained_glass/stained_glass8"
   ]
 }

--- a/src/main/resources/data/forge/tags/blocks/stained_glass/stained_glass.json
+++ b/src/main/resources/data/forge/tags/blocks/stained_glass/stained_glass.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:stained_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/stained_glass/stained_glass2.json
+++ b/src/main/resources/data/forge/tags/blocks/stained_glass/stained_glass2.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:stained_glass2"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/stained_glass/stained_glass3.json
+++ b/src/main/resources/data/forge/tags/blocks/stained_glass/stained_glass3.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:stained_glass3"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/stained_glass/stained_glass4.json
+++ b/src/main/resources/data/forge/tags/blocks/stained_glass/stained_glass4.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:stained_glass4"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/stained_glass/stained_glass5.json
+++ b/src/main/resources/data/forge/tags/blocks/stained_glass/stained_glass5.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:stained_glass5"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/stained_glass/stained_glass6.json
+++ b/src/main/resources/data/forge/tags/blocks/stained_glass/stained_glass6.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:stained_glass6"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/stained_glass/stained_glass7.json
+++ b/src/main/resources/data/forge/tags/blocks/stained_glass/stained_glass7.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:stained_glass7"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/stained_glass/stained_glass8.json
+++ b/src/main/resources/data/forge/tags/blocks/stained_glass/stained_glass8.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:stained_glass8"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks.json
@@ -1,16 +1,16 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:torridite_block",
-    "divinerpg:bloodgem_block",
-    "divinerpg:rupee_block",
-    "divinerpg:realmite_block",
-    "divinerpg:arlemite_block",
-    "divinerpg:eden_block",
-    "divinerpg:wildwood_block",
-    "divinerpg:apalachia_block",
-    "divinerpg:skythern_block",
-    "divinerpg:mortum_block",
-    "divinerpg:arcanium_block"
+    "#forge:storage_blocks/torridite",
+    "#forge:storage_blocks/bloodgem",
+    "#forge:storage_blocks/rupee",
+    "#forge:storage_blocks/realmite",
+    "#forge:storage_blocks/arlemite",
+    "#forge:storage_blocks/eden",
+    "#forge:storage_blocks/wildwood",
+    "#forge:storage_blocks/apalachia",
+    "#forge:storage_blocks/skythern",
+    "#forge:storage_blocks/mortum",
+    "#forge:storage_blocks/arcanium"
   ]
 }

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/apalachia.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/apalachia.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:apalachia_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/arcanium.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/arcanium.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:arcanium_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/arlemite.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/arlemite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:arlemite_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/bloodgem.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/bloodgem.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:bloodgem_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/eden.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/eden.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eden_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/mortum.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/mortum.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:mortum_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/realmite.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/realmite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:realmite_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/rupee.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/rupee.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:rupee_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/skythern.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/skythern.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:skythern_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/torridite.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/torridite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:torridite_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/wildwood.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/wildwood.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:wildwood_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/chests.json
+++ b/src/main/resources/data/forge/tags/items/chests.json
@@ -1,9 +1,9 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:eden_chest",
-    "divinerpg:bone_chest",
-    "divinerpg:present_box",
-    "divinerpg:frosted_chest"
+    "#forge:chests/eden",
+    "#forge:chests/bone",
+    "#forge:chests/present",
+    "#forge:chests/frosted"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/chests/bone.json
+++ b/src/main/resources/data/forge/tags/items/chests/bone.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:bone_chest"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/chests/eden.json
+++ b/src/main/resources/data/forge/tags/items/chests/eden.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eden_chest"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/chests/frosted.json
+++ b/src/main/resources/data/forge/tags/items/chests/frosted.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:frosted_chest"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/chests/present.json
+++ b/src/main/resources/data/forge/tags/items/chests/present.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:present_box"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/dirt.json
+++ b/src/main/resources/data/forge/tags/items/dirt.json
@@ -1,21 +1,13 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:frozen_dirt",
-    "divinerpg:frozen_grass",
-    "divinerpg:eden_dirt",
-    "divinerpg:eden_grass",
-    "divinerpg:wildwood_dirt",
-    "divinerpg:wildwood_grass",
-    "divinerpg:apalachia_dirt",
-    "divinerpg:apalachia_grass",
-    "divinerpg:skythern_dirt",
-    "divinerpg:skythern_grass",
-    "divinerpg:mortum_dirt",
-    "divinerpg:mortum_grass",
-    "divinerpg:arcanite_dirt",
-    "divinerpg:arcanite_grass",
-    "divinerpg:dream_dirt",
-    "divinerpg:dream_grass"
+    "#forge:dirts/frozen",
+    "#forge:dirts/eden",
+    "#forge:dirts/wildwood",
+    "#forge:dirts/apalachia",
+    "#forge:dirts/skythern",
+    "#forge:dirts/mortum",
+    "#forge:dirts/arcanite",
+    "#forge:dirts/dream"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/dirts/apalachia.json
+++ b/src/main/resources/data/forge/tags/items/dirts/apalachia.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:apalachia_dirt",
+    "divinerpg:apalachia_grass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/dirts/arcanite.json
+++ b/src/main/resources/data/forge/tags/items/dirts/arcanite.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:arcanite_dirt",
+    "divinerpg:arcanite_grass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/dirts/dream.json
+++ b/src/main/resources/data/forge/tags/items/dirts/dream.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:dream_dirt",
+    "divinerpg:dream_grass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/dirts/eden.json
+++ b/src/main/resources/data/forge/tags/items/dirts/eden.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eden_dirt",
+    "divinerpg:eden_grass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/dirts/frozen.json
+++ b/src/main/resources/data/forge/tags/items/dirts/frozen.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:frozen_dirt",
+    "divinerpg:frozen_grass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/dirts/mortum.json
+++ b/src/main/resources/data/forge/tags/items/dirts/mortum.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:mortum_dirt",
+    "divinerpg:mortum_grass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/dirts/skythern.json
+++ b/src/main/resources/data/forge/tags/items/dirts/skythern.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:skythern_dirt",
+    "divinerpg:skythern_grass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/dirts/wildwood.json
+++ b/src/main/resources/data/forge/tags/items/dirts/wildwood.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:wildwood_dirt",
+    "divinerpg:wildwood_grass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fence_gates.json
+++ b/src/main/resources/data/forge/tags/items/fence_gates.json
@@ -1,13 +1,13 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:eden_fence_gate",
-    "divinerpg:wildwood_fence_gate",
-    "divinerpg:apalachia_fence_gate",
-    "divinerpg:skythern_fence_gate",
-    "divinerpg:mortum_fence_gate",
-    "divinerpg:divine_fence_gate",
-    "divinerpg:frozen_fence_gate",
-    "divinerpg:eucalyptus_fence_gate"
+    "#forge:fence_gates/eden",
+    "#forge:fence_gates/wildwood",
+    "#forge:fence_gates/apalachia",
+    "#forge:fence_gates/skythern",
+    "#forge:fence_gates/mortum",
+    "#forge:fence_gates/divine",
+    "#forge:fence_gates/frozen",
+    "#forge:fence_gates/eucalyptus"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/fence_gates/apalachia.json
+++ b/src/main/resources/data/forge/tags/items/fence_gates/apalachia.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:apalachia_fence_gate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fence_gates/divine.json
+++ b/src/main/resources/data/forge/tags/items/fence_gates/divine.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:divine_fence_gate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fence_gates/eden.json
+++ b/src/main/resources/data/forge/tags/items/fence_gates/eden.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eden_fence_gate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fence_gates/eucalyptus.json
+++ b/src/main/resources/data/forge/tags/items/fence_gates/eucalyptus.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eucalyptus_fence_gate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fence_gates/frozen.json
+++ b/src/main/resources/data/forge/tags/items/fence_gates/frozen.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:frozen_fence_gate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fence_gates/mortum.json
+++ b/src/main/resources/data/forge/tags/items/fence_gates/mortum.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:mortum_fence_gate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fence_gates/skythern.json
+++ b/src/main/resources/data/forge/tags/items/fence_gates/skythern.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:skythern_fence_gate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fence_gates/wildwood.json
+++ b/src/main/resources/data/forge/tags/items/fence_gates/wildwood.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:wildwood_fence_gate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fences.json
+++ b/src/main/resources/data/forge/tags/items/fences.json
@@ -1,16 +1,16 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:blue_fence",
-    "divinerpg:green_fence",
-    "divinerpg:red_fence",
-    "divinerpg:eden_fence",
-    "divinerpg:wildwood_fence",
-    "divinerpg:apalachia_fence",
-    "divinerpg:skythern_fence",
-    "divinerpg:mortum_fence",
-    "divinerpg:divine_fence",
-    "divinerpg:frozen_fence",
-    "divinerpg:eucalyptus_fence"
+    "#forge:fences/blue",
+    "#forge:fences/green",
+    "#forge:fences/red",
+    "#forge:fences/eden",
+    "#forge:fences/wildwood",
+    "#forge:fences/apalachia",
+    "#forge:fences/skythern",
+    "#forge:fences/mortum",
+    "#forge:fences/divine",
+    "#forge:fences/frozen",
+    "#forge:fences/eucalyptus"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/fences/apalachia.json
+++ b/src/main/resources/data/forge/tags/items/fences/apalachia.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:apalachia_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fences/blue.json
+++ b/src/main/resources/data/forge/tags/items/fences/blue.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:blue_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fences/divine.json
+++ b/src/main/resources/data/forge/tags/items/fences/divine.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:divine_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fences/eden.json
+++ b/src/main/resources/data/forge/tags/items/fences/eden.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eden_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fences/eucalyptus.json
+++ b/src/main/resources/data/forge/tags/items/fences/eucalyptus.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eucalyptus_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fences/fronzen.json
+++ b/src/main/resources/data/forge/tags/items/fences/fronzen.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:frozen_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fences/green.json
+++ b/src/main/resources/data/forge/tags/items/fences/green.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:green_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fences/mortum.json
+++ b/src/main/resources/data/forge/tags/items/fences/mortum.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:mortum_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fences/red.json
+++ b/src/main/resources/data/forge/tags/items/fences/red.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:red_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fences/skythern.json
+++ b/src/main/resources/data/forge/tags/items/fences/skythern.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:skythern_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fences/wildwood.json
+++ b/src/main/resources/data/forge/tags/items/fences/wildwood.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:wildwood_fence"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/gems.json
+++ b/src/main/resources/data/forge/tags/items/gems.json
@@ -1,11 +1,11 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:bloodgem",
-    "divinerpg:eden_gem",
-    "divinerpg:wildwood_gem",
-    "divinerpg:apalachia_gem",
-    "divinerpg:skythern_gem",
-    "divinerpg:mortum_gem"
+    "#forge:gems/bloodgem",
+    "#forge:gems/eden",
+    "#forge:gems/wildwood",
+    "#forge:gems/apalachia",
+    "#forge:gems/skythern",
+    "#forge:gems/mortum"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/gems/apalachia.json
+++ b/src/main/resources/data/forge/tags/items/gems/apalachia.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:apalachia_gem"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/gems/bloodgem.json
+++ b/src/main/resources/data/forge/tags/items/gems/bloodgem.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:bloodgem"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/gems/eden.json
+++ b/src/main/resources/data/forge/tags/items/gems/eden.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eden_gem"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/gems/mortum.json
+++ b/src/main/resources/data/forge/tags/items/gems/mortum.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:mortum_gem"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/gems/skythern.json
+++ b/src/main/resources/data/forge/tags/items/gems/skythern.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:skythern_gem"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/gems/wildwood.json
+++ b/src/main/resources/data/forge/tags/items/gems/wildwood.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:wildwood_gem"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass.json
+++ b/src/main/resources/data/forge/tags/items/glass.json
@@ -1,15 +1,8 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:frosted_glass",
-    "divinerpg:stained_glass8",
-    "divinerpg:stained_glass",
-    "divinerpg:stained_glass2",
-    "divinerpg:stained_glass3",
-    "divinerpg:stained_glass4",
-    "divinerpg:stained_glass5",
-    "divinerpg:stained_glass6",
-    "divinerpg:stained_glass7",
-    "divinerpg:smooth_glass"
+    "#forge:glass/frosted",
+    "#forge:glass/stained",
+    "#forge:glass/smooth"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/glass/frosted.json
+++ b/src/main/resources/data/forge/tags/items/glass/frosted.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:frosted_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/smooth.json
+++ b/src/main/resources/data/forge/tags/items/glass/smooth.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:smooth_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/glass/stained.json
+++ b/src/main/resources/data/forge/tags/items/glass/stained.json
@@ -1,0 +1,13 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:stained_glass8",
+    "divinerpg:stained_glass",
+    "divinerpg:stained_glass2",
+    "divinerpg:stained_glass3",
+    "divinerpg:stained_glass4",
+    "divinerpg:stained_glass5",
+    "divinerpg:stained_glass6",
+    "divinerpg:stained_glass7"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ingots.json
+++ b/src/main/resources/data/forge/tags/items/ingots.json
@@ -1,11 +1,11 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:arlemite_ingot",
-    "divinerpg:realmite_ingot",
-    "divinerpg:rupee_ingot",
-    "divinerpg:torridite_ingot",
-    "divinerpg:hellstone_ingot",
-    "divinerpg:aquatic_ingot"
+    "#forge:ingots/arlemite",
+    "#forge:ingots/realmite",
+    "#forge:ingots/rupee",
+    "#forge:ingots/torridite",
+    "#forge:ingots/hellstone",
+    "#forge:ingots/aquatic"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/ingots/aquatic.json
+++ b/src/main/resources/data/forge/tags/items/ingots/aquatic.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:aquatic_ingot"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ingots/arlemite.json
+++ b/src/main/resources/data/forge/tags/items/ingots/arlemite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:arlemite_ingot"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ingots/hellstone.json
+++ b/src/main/resources/data/forge/tags/items/ingots/hellstone.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:hellstone_ingot"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ingots/realmite.json
+++ b/src/main/resources/data/forge/tags/items/ingots/realmite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:realmite_ingot"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ingots/rupee.json
+++ b/src/main/resources/data/forge/tags/items/ingots/rupee.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:rupee_ingot"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ingots/torridite.json
+++ b/src/main/resources/data/forge/tags/items/ingots/torridite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:torridite_ingot"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/nuggets.json
+++ b/src/main/resources/data/forge/tags/items/nuggets.json
@@ -1,9 +1,9 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:arlemite_nugget",
-    "divinerpg:realmite_nugget",
-    "divinerpg:rupee_nugget",
-    "divinerpg:torridite_nugget"
+    "#forge:nuggets/arlemite",
+    "#forge:nuggets/realmite",
+    "#forge:nuggets/rupee",
+    "#forge:nuggets/torridite"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/nuggets/arlemite.json
+++ b/src/main/resources/data/forge/tags/items/nuggets/arlemite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:arlemite_nugget"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/nuggets/realmite.json
+++ b/src/main/resources/data/forge/tags/items/nuggets/realmite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:realmite_nugget"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/nuggets/rupee.json
+++ b/src/main/resources/data/forge/tags/items/nuggets/rupee.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:rupee_nugget"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/nuggets/torridite.json
+++ b/src/main/resources/data/forge/tags/items/nuggets/torridite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:torridite_nugget"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores.json
+++ b/src/main/resources/data/forge/tags/items/ores.json
@@ -1,15 +1,15 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:arlemite_ore",
-    "divinerpg:realmite_ore",
-    "divinerpg:rupee_ore",
-    "divinerpg:bloodgem_ore",
-    "divinerpg:torridite_ore",
-    "divinerpg:eden_ore",
-    "divinerpg:wildwood_ore",
-    "divinerpg:apalachia_ore",
-    "divinerpg:skythern_ore",
-    "divinerpg:mortum_ore"
+    "#forge:ores/arlemite",
+    "#forge:ores/realmite",
+    "#forge:ores/rupee",
+    "#forge:ores/bloodgem",
+    "#forge:ores/torridite",
+    "#forge:ores/eden",
+    "#forge:ores/wildwood",
+    "#forge:ores/apalachia",
+    "#forge:ores/skythern",
+    "#forge:ores/mortum"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/ores/apalachia.json
+++ b/src/main/resources/data/forge/tags/items/ores/apalachia.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:apalachia_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/arlemite.json
+++ b/src/main/resources/data/forge/tags/items/ores/arlemite.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:arlemite_ore",
+    "divinerpg:arlemite_ore_deepslate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/bloodgem.json
+++ b/src/main/resources/data/forge/tags/items/ores/bloodgem.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:bloodgem_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/eden.json
+++ b/src/main/resources/data/forge/tags/items/ores/eden.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eden_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/mortum.json
+++ b/src/main/resources/data/forge/tags/items/ores/mortum.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:mortum_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/realmite.json
+++ b/src/main/resources/data/forge/tags/items/ores/realmite.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:realmite_ore",
+    "divinerpg:realmite_ore_deepslate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/rupee.json
+++ b/src/main/resources/data/forge/tags/items/ores/rupee.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:rupee_ore",
+    "divinerpg:rupee_ore_deepslate"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/skythern.json
+++ b/src/main/resources/data/forge/tags/items/ores/skythern.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:skythern_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/torridite.json
+++ b/src/main/resources/data/forge/tags/items/ores/torridite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:torridite_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/wildwood.json
+++ b/src/main/resources/data/forge/tags/items/ores/wildwood.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:wildwood_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds.json
+++ b/src/main/resources/data/forge/tags/items/seeds.json
@@ -1,19 +1,19 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:aquamarine_seeds",
-    "divinerpg:eucalyptus_root_seeds",
-    "divinerpg:firestock_seeds",
-    "divinerpg:hitchak_seeds",
-    "divinerpg:lamona_seeds",
-    "divinerpg:marsine_seeds",
-    "divinerpg:moonbulb_seeds",
-    "divinerpg:pinfly_seeds",
-    "divinerpg:pink_glowbone_seeds",
-    "divinerpg:purple_glowbone_seeds",
-    "divinerpg:sky_plant_seeds",
-    "divinerpg:tomato_seeds",
-    "divinerpg:veilo_seeds",
-    "divinerpg:white_mushroom_seeds"
+    "#forge:seeds/aquamarine",
+    "#forge:seeds/eucalyptus_root",
+    "#forge:seeds/firestock",
+    "#forge:seeds/hitchak",
+    "#forge:seeds/lamona",
+    "#forge:seeds/marsine",
+    "#forge:seeds/moonbulb",
+    "#forge:seeds/pinfly",
+    "#forge:seeds/pink_glowbone",
+    "#forge:seeds/purple_glowbone",
+    "#forge:seeds/sky_plant",
+    "#forge:seeds/tomato",
+    "#forge:seeds/veilo_",
+    "#forge:seeds/white_mushroom"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/seeds/aquamarine.json
+++ b/src/main/resources/data/forge/tags/items/seeds/aquamarine.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:aquamarine_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/eucalyptus_root.json
+++ b/src/main/resources/data/forge/tags/items/seeds/eucalyptus_root.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eucalyptus_root_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/firestock.json
+++ b/src/main/resources/data/forge/tags/items/seeds/firestock.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:firestock_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/hitchak.json
+++ b/src/main/resources/data/forge/tags/items/seeds/hitchak.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:hitchak_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/lamona.json
+++ b/src/main/resources/data/forge/tags/items/seeds/lamona.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:lamona_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/marsine.json
+++ b/src/main/resources/data/forge/tags/items/seeds/marsine.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:marsine_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/moonbulb.json
+++ b/src/main/resources/data/forge/tags/items/seeds/moonbulb.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:moonbulb_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/pinfly.json
+++ b/src/main/resources/data/forge/tags/items/seeds/pinfly.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:pinfly_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/pink_glowbone.json
+++ b/src/main/resources/data/forge/tags/items/seeds/pink_glowbone.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:pink_glowbone_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/purple_glowbone.json
+++ b/src/main/resources/data/forge/tags/items/seeds/purple_glowbone.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:purple_glowbone_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/sky_plant.json
+++ b/src/main/resources/data/forge/tags/items/seeds/sky_plant.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:sky_plant_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/tomato.json
+++ b/src/main/resources/data/forge/tags/items/seeds/tomato.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:tomato_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/veilo.json
+++ b/src/main/resources/data/forge/tags/items/seeds/veilo.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:veilo_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/white_mushroom.json
+++ b/src/main/resources/data/forge/tags/items/seeds/white_mushroom.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:white_mushroom_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/slimeballs.json
+++ b/src/main/resources/data/forge/tags/items/slimeballs.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:aqua_ball"
+    "#forge:slimeballs/aqua_ball"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/slimeballs/aqua_ball.json
+++ b/src/main/resources/data/forge/tags/items/slimeballs/aqua_ball.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:aqua_ball"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/stained_glass.json
+++ b/src/main/resources/data/forge/tags/items/stained_glass.json
@@ -1,13 +1,13 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:stained_glass",
-    "divinerpg:stained_glass2",
-    "divinerpg:stained_glass3",
-    "divinerpg:stained_glass4",
-    "divinerpg:stained_glass5",
-    "divinerpg:stained_glass6",
-    "divinerpg:stained_glass7",
-    "divinerpg:stained_glass8"
+    "#forge:stained_glass/stained_glass",
+    "#forge:stained_glass/stained_glass2",
+    "#forge:stained_glass/stained_glass3",
+    "#forge:stained_glass/stained_glass4",
+    "#forge:stained_glass/stained_glass5",
+    "#forge:stained_glass/stained_glass6",
+    "#forge:stained_glass/stained_glass7",
+    "#forge:stained_glass/stained_glass8"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/stained_glass/stained_glass.json
+++ b/src/main/resources/data/forge/tags/items/stained_glass/stained_glass.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:stained_glass"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/stained_glass/stained_glass2.json
+++ b/src/main/resources/data/forge/tags/items/stained_glass/stained_glass2.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:stained_glass2"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/stained_glass/stained_glass3.json
+++ b/src/main/resources/data/forge/tags/items/stained_glass/stained_glass3.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:stained_glass3"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/stained_glass/stained_glass4.json
+++ b/src/main/resources/data/forge/tags/items/stained_glass/stained_glass4.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:stained_glass4"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/stained_glass/stained_glass5.json
+++ b/src/main/resources/data/forge/tags/items/stained_glass/stained_glass5.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:stained_glass5"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/stained_glass/stained_glass6.json
+++ b/src/main/resources/data/forge/tags/items/stained_glass/stained_glass6.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:stained_glass6"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/stained_glass/stained_glass7.json
+++ b/src/main/resources/data/forge/tags/items/stained_glass/stained_glass7.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:stained_glass7"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/stained_glass/stained_glass8.json
+++ b/src/main/resources/data/forge/tags/items/stained_glass/stained_glass8.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:stained_glass8"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks.json
@@ -1,16 +1,16 @@
 {
   "replace": false,
   "values": [
-    "divinerpg:torridite_block",
-    "divinerpg:bloodgem_block",
-    "divinerpg:rupee_block",
-    "divinerpg:realmite_block",
-    "divinerpg:arlemite_block",
-    "divinerpg:eden_block",
-    "divinerpg:wildwood_block",
-    "divinerpg:apalachia_block",
-    "divinerpg:skythern_block",
-    "divinerpg:mortum_block",
-    "divinerpg:arcanium_block"
+    "#forge:storage_blocks/torridite",
+    "#forge:storage_blocks/bloodgem_",
+    "#forge:storage_blocks/rupee",
+    "#forge:storage_blocks/realmite",
+    "#forge:storage_blocks/arlemite",
+    "#forge:storage_blocks/eden",
+    "#forge:storage_blocks/wildwood",
+    "#forge:storage_blocks/apalachia",
+    "#forge:storage_blocks/skythern",
+    "#forge:storage_blocks/mortum",
+    "#forge:storage_blocks/arcanium"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/storage_blocks/apalachia.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/apalachia.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:apalachia_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/arcanium.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/arcanium.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:arcanium_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/arlemite.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/arlemite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:arlemite_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/bloodgem.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/bloodgem.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:bloodgem_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/eden.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/eden.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:eden_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/mortum.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/mortum.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:mortum_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/realmite.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/realmite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:realmite_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/rupee.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/rupee.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:rupee_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/skythern.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/skythern.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:skythern_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/torridite.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/torridite.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:torridite_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/wildwood.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/wildwood.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "divinerpg:wildwood_block"
+  ]
+}


### PR DESCRIPTION
Made the tags in resources/data/forge/tags more in line with forge standards. For example, arlemite, realmite, and rupee all have their own ore tag now, and a universal ores tag that uses the individual tags.