### PR TITLE
Disallow ender spiders from spawning in light

### DIFF
--- a/src/main/java/divinerpg/events/SpawnEvents.java
+++ b/src/main/java/divinerpg/events/SpawnEvents.java
@@ -112,7 +112,7 @@ public class SpawnEvents {
 		register(e, SCORCHER.get(), SpawnType.FLY, MONSTER);
 		register(e, WILDFIRE.get(), SpawnType.GROUND, MONSTER);
     	//End
-		register(e, ENDER_SPIDER.get(), SpawnType.AGILE, MONSTER_DARKNESS_AGILE);
+		register(e, ENDER_SPIDER.get(), SpawnType.AGILE, MONSTER);
 		register(e, ENDER_TRIPLETS.get(), SpawnType.GROUND, (en, s, t, p, r) -> difficultyFilter(en, s, t, p, r) && p.getY() > 60);
 		register(e, ENDER_WATCHER.get(), SpawnType.GROUND, MONSTER);
 		register(e, ENDER_SCROUNGE.get(), SpawnType.GROUND, DARKNESS);


### PR DESCRIPTION
ender spiders have caused me and my friends many issues regarding farms, specifically farms with minecarts. They spawn in the light, despite us lighting up our base very far around, then they teleport due to rain into cover where minecarts move around to pick up items.

This PR removes the ender spiders' ability to spawn in the light